### PR TITLE
B3 codec is not used even when enabled, when another customizer is present

### DIFF
--- a/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
+++ b/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
@@ -62,9 +62,8 @@ public class JaegerAutoConfiguration {
   private String serviceName;
 
   @Bean
-  public io.opentracing.Tracer tracer(JaegerConfigurationProperties jaegerConfigurationProperties,
-        Sampler sampler,
-        Reporter reporter) {
+  public io.opentracing.Tracer tracer(Sampler sampler,
+                                      Reporter reporter) {
 
     final Builder builder =
         new Builder(serviceName)
@@ -159,12 +158,6 @@ public class JaegerAutoConfiguration {
     return new NoopMetricsFactory();
   }
 
-  @ConditionalOnProperty(value = "opentracing.jaeger.enable-b3-propagation", havingValue = "true")
-  @Bean
-  public TracerBuilderCustomizer b3CodecJaegerTracerCustomizer() {
-    return new B3CodecTracerBuilderCustomizer();
-  }
-
   /**
    * Decide on what Sampler to use based on the various configuration options in
    * JaegerConfigurationProperties Fallback to ConstSampler(true) when no Sampler is configured
@@ -200,4 +193,13 @@ public class JaegerAutoConfiguration {
     return new ConstSampler(true);
   }
 
+  @Configuration
+  @ConditionalOnProperty(value = "opentracing.jaeger.enable-b3-propagation")
+  public static class B3CodecConfiguration {
+
+    @Bean
+    public TracerBuilderCustomizer b3CodecJaegerTracerCustomizer() {
+      return new B3CodecTracerBuilderCustomizer();
+    }
+  }
 }

--- a/opentracing-spring-jaeger-starter/src/test/java/io/opentracing/contrib/java/spring/jaeger/starter/customizer/JaegerTracerB3CustomizerCustomSpringTest.java
+++ b/opentracing-spring-jaeger-starter/src/test/java/io/opentracing/contrib/java/spring/jaeger/starter/customizer/JaegerTracerB3CustomizerCustomSpringTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.java.spring.jaeger.starter.customizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jaegertracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.java.spring.jaeger.starter.AbstractTracerSpringTest;
+import io.opentracing.contrib.java.spring.jaeger.starter.TracerBuilderCustomizer;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMapExtractAdapter;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+
+@TestPropertySource(
+    properties = {
+        "spring.main.banner-mode=off",
+        "opentracing.jaeger.enable-b3-propagation=true"
+    }
+)
+@Import(JaegerTracerB3CustomizerCustomSpringTest.TestConfiguration.class)
+public class JaegerTracerB3CustomizerCustomSpringTest extends AbstractTracerSpringTest {
+
+  @Autowired
+  private Tracer tracer;
+
+  public static class TestConfiguration {
+    @Bean
+    public TracerBuilderCustomizer myCustomizer() {
+      // Noop
+      return builder -> {
+      };
+    }
+  }
+
+  @Test
+  public void testCustomizersShouldContainB3Customizer() {
+    Map<String, String> carrier = new HashMap<>();
+    carrier.put("X-B3-TraceId", "abc");
+    carrier.put("X-B3-SpanId", "def");
+
+    SpanContext context = (SpanContext) tracer.extract(Format.Builtin.HTTP_HEADERS, new TextMapExtractAdapter(carrier));
+
+    // Note: This test ensures that B3 codec actually works
+    // If it would not, values would never be extracted from B3 headers and context will be null
+    assertThat(context).isNotNull();
+    assertThat(context.getTraceId()).isEqualTo(0xabc);
+    assertThat(context.getSpanId()).isEqualTo(0xdef);
+  }
+}


### PR DESCRIPTION
This is followup for https://github.com/opentracing-contrib/java-spring-cloud/pull/129

In contrast to original PR, moved `B3CodecTracerBuilderCustomizer` to nested conditional config class (its probably cleaner this way, since Spring will order config classes properly on its own).

Added separate unit test to test specifically this issue as `JaegerTracerB3CustomizerCustomSpringTest`. Note that this test verifies codec is actually used by the tracer, instead of verifying customizer is registered in Spring context (which are two very different things).

Review as always please :)
