### PR TITLE
Run jaeger configuration before Noop tracer producer

### DIFF
--- a/opentracing-spring-jaeger-starter/pom.xml
+++ b/opentracing-spring-jaeger-starter/pom.xml
@@ -31,6 +31,11 @@
 
     <dependencies>
       <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-spring-tracer}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-autoconfigure</artifactId>
         <optional>true</optional>

--- a/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
+++ b/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
@@ -51,7 +51,7 @@ import org.springframework.util.StringUtils;
 @ConditionalOnClass(io.jaegertracing.Tracer.class)
 @ConditionalOnMissingBean(io.opentracing.Tracer.class)
 @ConditionalOnProperty(value = "opentracing.jaeger.enabled", havingValue = "true", matchIfMissing = true)
-@AutoConfigureBefore(name = "io.opentracing.contrib.spring.web.autoconfig.TracerAutoConfiguration")
+@AutoConfigureBefore(io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration.class)
 @EnableConfigurationProperties(JaegerConfigurationProperties.class)
 public class JaegerAutoConfiguration {
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <version.io.opentracing>0.31.0</version.io.opentracing>
+    <version.io.opentracing.contrib-opentracing-spring-tracer>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer>
     <version.org.springframework.boot>1.5.12.RELEASE</version.org.springframework.boot>
     <version.jaeger>0.27.0</version.jaeger>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>


### PR DESCRIPTION
Without this tracer configuration can kick in before and produce noop tracer.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>