### PR TITLE
Set 'metrics' object on the Tracer itself.

### DIFF
--- a/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
+++ b/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
@@ -63,12 +63,14 @@ public class JaegerAutoConfiguration {
 
   @Bean
   public io.opentracing.Tracer tracer(Sampler sampler,
-                                      Reporter reporter) {
+                                      Reporter reporter,
+                                      Metrics metrics) {
 
     final JaegerTracer.Builder builder =
         new JaegerTracer.Builder(serviceName)
             .withReporter(reporter)
-            .withSampler(sampler);
+            .withSampler(sampler)
+            .withMetrics(metrics);
 
     tracerCustomizers.forEach(c -> c.customize(builder));
 

--- a/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
+++ b/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerAutoConfiguration.java
@@ -152,7 +152,7 @@ public class JaegerAutoConfiguration {
 
   @ConditionalOnMissingBean
   @Bean
-  public Metrics reporterMetrics(MetricsFactory metricsFactory) {
+  public Metrics metrics(MetricsFactory metricsFactory) {
     return new Metrics(metricsFactory);
   }
 


### PR DESCRIPTION
The `Tracer` object can make use of the `Metrics` class to record stats such as finished spans, sampling counts, and more.

This PR sets the `metrics` object on the tracer builder, so that Tracer level metrics are published to the configured `metrics` instance instead of a `Noop` default instance.