### PR TITLE
Respect jaeger.service-name property

### DIFF
--- a/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerConfigurationProperties.java
+++ b/opentracing-spring-jaeger-starter/src/main/java/io/opentracing/contrib/java/spring/jaeger/starter/JaegerConfigurationProperties.java
@@ -40,10 +40,9 @@ public class JaegerConfigurationProperties {
 
   /**
    * Service name to be used
-   * By default it will be the value of the 'spring.application.name' property name
-   * and if that is not set, it falls back to 'unknown-spring-boot'
+   * Expect certain properties in order, falling back to 'unknown-spring-boot'.
    */
-  @Value("${spring.application.name:unknown-spring-boot}")
+  @Value("${jaeger.service-name:${spring.application.name:unknown-spring-boot}}")
   private String serviceName;
 
   /**

--- a/opentracing-spring-jaeger-starter/src/test/java/io/opentracing/contrib/java/spring/jaeger/starter/basic/JaegerTracerServiceNameSetWithoutOpentracingPrefixTest.java
+++ b/opentracing-spring-jaeger-starter/src/test/java/io/opentracing/contrib/java/spring/jaeger/starter/basic/JaegerTracerServiceNameSetWithoutOpentracingPrefixTest.java
@@ -14,11 +14,11 @@
 
 package io.opentracing.contrib.java.spring.jaeger.starter.basic;
 
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
 import io.opentracing.contrib.java.spring.jaeger.starter.AbstractTracerSpringTest;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
-
-import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @TestPropertySource(
     properties = {

--- a/opentracing-spring-jaeger-starter/src/test/java/io/opentracing/contrib/java/spring/jaeger/starter/basic/JaegerTracerServiceNameSetWithoutOpentracingPrefixTest.java
+++ b/opentracing-spring-jaeger-starter/src/test/java/io/opentracing/contrib/java/spring/jaeger/starter/basic/JaegerTracerServiceNameSetWithoutOpentracingPrefixTest.java
@@ -14,29 +14,28 @@
 
 package io.opentracing.contrib.java.spring.jaeger.starter.basic;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
-
 import io.opentracing.contrib.java.spring.jaeger.starter.AbstractTracerSpringTest;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
 
 @TestPropertySource(
     properties = {
         "spring.main.banner-mode=off",
         "opentracing.jaeger.enabled=true",
-        "spring.application.name=foo",
-        "app.env=stage",
-        "jaeger.service-name=please-override",
-        "opentracing.jaeger.service-name=${spring.application.name}-${app.env}"
+        "jaeger.service-name=foo",
+        "spring.application.name=bar"
     }
 )
-public class JaegerTracerServiceNameSetExplicitWithPropsTest extends AbstractTracerSpringTest {
+public class JaegerTracerServiceNameSetWithoutOpentracingPrefixTest extends AbstractTracerSpringTest {
 
   @Test
   public void testNameIsAsExpected() {
     assertThat(tracer).isNotNull();
     assertThat(tracer).isInstanceOf(io.jaegertracing.internal.JaegerTracer.class);
 
-    assertThat((getTracer()).getServiceName()).isEqualTo("foo-stage");
+    // 'jaeger.service-name' should take priority over 'spring.application.name'
+    assertThat((getTracer()).getServiceName()).isEqualTo("foo");
   }
 }


### PR DESCRIPTION
JAEGER_SERVICE_NAME is an environment variable set by e.g. the
jaeger-operator when it injects environment variables into containers.

This change means that Spring apps can use the auto-container inject
feature of the operator and be identified correctly by default.

See https://www.jaegertracing.io/docs/1.13/client-features/

See #56