### PR TITLE
Update Readme with solution for trace forwarding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,17 @@ In the code above we are activating a `io.opentracing.Tracer` iff `opentracing.j
 is necessary to keep the various Spring configurations happy but has been configured to not sample any requests, therefore
 effectively disabling tracing.
 
+### Trace id not being forwarded
+
+In some cases it might be necessary to explicitely expose the Feign client in the Spring configuration. This can be done easily by adding the following into one of your configuration classes:
+
+```
+@Bean
+public Client feignClient() {
+    return new Client.Default(null, null);
+}
+```
+
 ## Release
 Follow instructions in [RELEASE](RELEASE.md)
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ In the code above we are activating a `io.opentracing.Tracer` iff `opentracing.j
 is necessary to keep the various Spring configurations happy but has been configured to not sample any requests, therefore
 effectively disabling tracing.
 
-### Trace id not being forwarded
+### Trace id not propagated via the Feign client 
 
-In some cases it might be necessary to explicitely expose the Feign client in the Spring configuration. This can be done easily by adding the following into one of your configuration classes:
+If you are using Feign, in some cases it might be necessary to explicitely expose the Feign client in the Spring configuration, in order to get the `uber-trace-id` propagated. This can be done easily by adding the following into one of your configuration classes:
 
 ```
 @Bean


### PR DESCRIPTION
This provides a solution for some cases where the `uber-trace-id` is not retransmitted as mentioned in https://github.com/opentracing-contrib/java-spring-jaeger/issues/71