### PR TITLE
Bump jaeger-client to 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer>0.3.1</version.io.opentracing.contrib-opentracing-spring-tracer>
     <version.org.springframework.boot>2.1.4.RELEASE</version.org.springframework.boot>
-    <version.jaeger>1.1.0</version.jaeger>
+    <version.jaeger>1.3.2</version.jaeger>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.test-containers>1.7.3</version.test-containers>
 


### PR DESCRIPTION
Not sure how the process is intended to work but it would be nice to have new features like 
https://github.com/opentracing-contrib/java-spring-jaeger/pull/60
in the starter.