### PR TITLE
Bump opentracing-spring-cloud-starter version property to 0.5.6

### DIFF
--- a/opentracing-spring-jaeger-cloud-starter/pom.xml
+++ b/opentracing-spring-jaeger-cloud-starter/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <opentracing-spring-cloud-starter.version>0.5.3</opentracing-spring-cloud-starter.version>
+    <opentracing-spring-cloud-starter.version>0.5.6</opentracing-spring-cloud-starter.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The actual version of opentracing-spring-cloud-starter version 0.5.3 doesn´t support oracle drivers, you can see the problem in this
[issue](https://github.com/opentracing-contrib/java-spring-jaeger/issues/81), bump to 0.5.6 worked for me.
In my case i am using ojdbc6.