### PR TITLE
fix: Exclude spring-tracer from spring-web-starter import

### DIFF
--- a/opentracing-spring-jaeger-starter/pom.xml
+++ b/opentracing-spring-jaeger-starter/pom.xml
@@ -33,7 +33,6 @@
       <dependency>
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
-        <version>${version.io.opentracing.contrib-opentracing-spring-tracer}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/opentracing-spring-jaeger-web-starter/pom.xml
+++ b/opentracing-spring-jaeger-web-starter/pom.xml
@@ -27,7 +27,6 @@
 
     <properties>
       <main.basedir>${project.basedir}/..</main.basedir>
-      <opentracing-spring-web-starter.version>4.0.0</opentracing-spring-web-starter.version>
     </properties>
 
     <dependencies>
@@ -39,7 +38,6 @@
         <dependency>
             <groupId>io.opentracing.contrib</groupId>
             <artifactId>opentracing-spring-web-starter</artifactId>
-            <version>${opentracing-spring-web-starter.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer>0.4.0</version.io.opentracing.contrib-opentracing-spring-tracer>
+    <version.io.opentracing.contrib-opentracing-spring-web-starter>4.0.0</version.io.opentracing.contrib-opentracing-spring-web-starter>
     <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
     <version.jaeger>1.1.0</version.jaeger>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
@@ -123,6 +124,23 @@
         <artifactId>jaeger-client</artifactId>
         <version>${version.jaeger}</version>
       </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-spring-tracer}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-spring-web-starter</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-spring-web-starter}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Fixes a dependency convergence issue (until spring-web-starter fixes their version)
Also move some dependencies to the parent dependency management for consistency

Fixes #112 