### PR TITLE
#123 - update opentracing-spring-cloud-starter.version

### DIFF
--- a/opentracing-spring-jaeger-cloud-starter/pom.xml
+++ b/opentracing-spring-jaeger-cloud-starter/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-    <opentracing-spring-cloud-starter.version>0.5.3</opentracing-spring-cloud-starter.version>
+    <opentracing-spring-cloud-starter.version>0.5.9</opentracing-spring-cloud-starter.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Upgrade opentracing-spring-cloud-starter.version. 0.5.3 -> 0.5.9