### PR TITLE
Improve support of spring boot 3.0 (#146)

### DIFF
--- a/opentracing-spring-jaeger-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/opentracing-spring-jaeger-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+io.opentracing.contrib.java.spring.jaeger.starter.JaegerAutoConfiguration


### PR DESCRIPTION
Spring boot 2.7 introduces new way for registering autoconfiguration classes. And then spring.factories file was deprecated.
As of boot 3.0 support of spring.factories files was dropped.

See also:
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files